### PR TITLE
Sim fixes

### DIFF
--- a/microcontroller/Core/Inc/frequency.h
+++ b/microcontroller/Core/Inc/frequency.h
@@ -15,8 +15,8 @@ typedef struct {
 	uint32_t CalculationOK;
 	uint32_t Is_First_Captured;
 	uint32_t outlier_counter;
-	unsigned long Current_Frequency;
-	unsigned long Good_Frequency;
+	uint32_t Current_Frequency;
+	uint32_t Good_Frequency;
 } frequency_data;
 
 void freq_init(frequency_data * freq);

--- a/microcontroller/Core/Inc/frequency.h
+++ b/microcontroller/Core/Inc/frequency.h
@@ -8,10 +8,10 @@
 #define OUTLIER_THRESHOLD 10
 
 typedef struct {
-	unsigned long Difference;
-	unsigned long Frequency;
-	unsigned long IC_Value1;
-	unsigned long IC_Value2;
+	uint32_t Difference;
+	uint32_t Frequency;
+	uint32_t IC_Value1;
+	uint32_t IC_Value2;
 	uint32_t CalculationOK;
 	uint32_t Is_First_Captured;
 	uint32_t outlier_counter;

--- a/microcontroller/Core/Inc/frequency.h
+++ b/microcontroller/Core/Inc/frequency.h
@@ -5,17 +5,19 @@
 
 //Threshold values for outliers
 #define OUTLIER_COUNT 2
-#define OUTLIER_THRESHOLD 0.1
+#define OUTLIER_THRESHOLD 10
 
 typedef struct {
-	uint32_t Difference;
-	uint32_t Frequency;
-	uint32_t IC_Value1;
-	uint32_t IC_Value2;
+	unsigned long Difference;
+	unsigned long Frequency;
+	unsigned long IC_Value1;
+	unsigned long IC_Value2;
 	uint32_t CalculationOK;
-	uint32_t Is_first_Captured;
+	uint32_t Is_First_Captured;
 	uint32_t outlier_counter;
-	uint32_t Current_Frequency;
+	unsigned long Current_Frequency;
+	unsigned long Good_Frequency;
 } frequency_data;
 
+void freq_init(frequency_data * freq);
 int check_outliers(uint32_t curr_freq, uint32_t incoming_freq);

--- a/microcontroller/Core/Inc/pedcon.h
+++ b/microcontroller/Core/Inc/pedcon.h
@@ -5,6 +5,7 @@ uint32_t time_check;
 uint16_t first_v;
 uint16_t second_v;
 uint16_t user_v;
+uint16_t time_check_true;
 } pedal_con;
 
 int voltage_offset(uint16_t first_v, uint16_t second_v);

--- a/microcontroller/Core/Src/frequency.c
+++ b/microcontroller/Core/Src/frequency.c
@@ -1,5 +1,16 @@
 #include "frequency.h"
 
+void freq_init(frequency_data *freq) {
+	freq->Difference = 0;;
+	freq->Frequency = 0;
+	freq->IC_Value1 = 0;
+	freq->IC_Value2 = 0;
+	freq->CalculationOK = 0;
+	freq->Is_First_Captured = 0;
+	freq->outlier_counter = 0;
+	freq->Current_Frequency = 0;
+}
+
 int check_outliers(uint32_t curr_freq, uint32_t incoming_freq) {
 	uint32_t difference = incoming_freq > curr_freq ? incoming_freq - curr_freq: curr_freq - incoming_freq;
 	float average = (incoming_freq + curr_freq) / 2.0;

--- a/microcontroller/Core/Src/main.c
+++ b/microcontroller/Core/Src/main.c
@@ -1,20 +1,20 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file           : main.c
-  * @brief          : Main program body
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2023 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file           : main.c
+ * @brief          : Main program body
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2023 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
@@ -27,7 +27,6 @@
 #include "comm.h"
 #include "sdlog.h"
 #include "calc.h"
-#include <stdio.h>
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -79,9 +78,8 @@ static void MX_USART2_UART_Init(void);
 static void MX_SPI1_Init(void);
 /* USER CODE BEGIN PFP */
 //SD Card Globals
-
 FRESULT file_res;
-char * file_name = NULL;
+char *file_name = NULL;
 short int detect = 0;
 short int detect_last = 0;
 int file_length = 0;
@@ -98,657 +96,634 @@ throttle_percents throttle;
 /* USER CODE END 0 */
 
 /**
-  * @brief  The application entry point.
-  * @retval int
-  */
-int main(void)
-{
-  /* USER CODE BEGIN 1 */
-/*pedal_con pedal;
-pedal.first_v = 0;
-pedal.second_v = 0;
-pedal.user_v = 0;*/
+ * @brief  The application entry point.
+ * @retval int
+ */
+int main(void) {
+	/* USER CODE BEGIN 1 */
+	/*pedal_con pedal;
+	 pedal.first_v = 0;
+	 pedal.second_v = 0;
+	 pedal.user_v = 0;*/
 
-  /* USER CODE END 1 */
+	/* USER CODE END 1 */
 
-  /* MCU Configuration--------------------------------------------------------*/
+	/* MCU Configuration--------------------------------------------------------*/
 
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
-  HAL_Init();
+	/* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+	HAL_Init();
 
-  /* USER CODE BEGIN Init */
+	/* USER CODE BEGIN Init */
 
-  /* USER CODE END Init */
+	/* USER CODE END Init */
 
-  /* Configure the system clock */
-  SystemClock_Config();
+	/* Configure the system clock */
+	SystemClock_Config();
 
-  /* USER CODE BEGIN SysInit */
+	/* USER CODE BEGIN SysInit */
 
-  /* USER CODE END SysInit */
+	/* USER CODE END SysInit */
 
-  /* Initialize all configured peripherals */
-  MX_GPIO_Init();
-  MX_ADC1_Init();
-  MX_CAN1_Init();
-  MX_DAC_Init();
-  MX_TIM2_Init();
-  MX_TIM5_Init();
-  MX_ADC2_Init();
-  MX_ADC3_Init();
-  MX_USART2_UART_Init();
-  MX_SPI1_Init();
-  MX_FATFS_Init();
-  /* USER CODE BEGIN 2 */
-  HAL_TIM_IC_Start_IT(&htim2, TIM_CHANNEL_1);
-  HAL_TIM_IC_Start_IT(&htim5, TIM_CHANNEL_3);
-  HAL_ADC_Start_IT(&hadc1);
-  HAL_ADC_Start_IT(&hadc2);
-  HAL_ADC_Start_IT(&hadc3);
-  HAL_DAC_Start(&hdac, 1);
-  HAL_DAC_Start(&hdac, 2);
-  HAL_CAN_Start(&hcan1);
-  htim2.Channel = HAL_TIM_ACTIVE_CHANNEL_1;
-  htim5.Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+	/* Initialize all configured peripherals */
+	MX_GPIO_Init();
+	MX_ADC1_Init();
+	MX_CAN1_Init();
+	MX_DAC_Init();
+	MX_TIM2_Init();
+	MX_TIM5_Init();
+	MX_ADC2_Init();
+	MX_ADC3_Init();
+	MX_USART2_UART_Init();
+	MX_SPI1_Init();
+	MX_FATFS_Init();
+	/* USER CODE BEGIN 2 */
+	freq_init(&tim2);
+	freq_init(&tim5);
+	HAL_TIM_IC_Start_IT(&htim2, TIM_CHANNEL_1);
+	HAL_TIM_IC_Start_IT(&htim5, TIM_CHANNEL_2);
+	HAL_ADC_Start_IT(&hadc1);
+	HAL_ADC_Start_IT(&hadc2);
+	HAL_ADC_Start_IT(&hadc3);
+	HAL_DAC_Start(&hdac, 1);
+	HAL_DAC_Start(&hdac, 2);
+	HAL_CAN_Start(&hcan1);
+	htim2.Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+	htim5.Channel = HAL_TIM_ACTIVE_CHANNEL_2;
 
-  if(sd_mount("/") == FR_OK)
-	  //SD card detected
-	  detect = 1;
-  else
-	  //SD card not detected
-	  detect = 0;
-  sd_unmount("/");
+	if (sd_mount("/") == FR_OK)
+		//SD card detected
+		detect = 1;
+	else
+		//SD card not detected
+		detect = 0;
+	sd_unmount("/");
 
-  /* USER CODE END 2 */
+	/* USER CODE END 2 */
 
-  /* Infinite loop */
-  /* USER CODE BEGIN WHILE */
-  while (1)
-  {
+	/* Infinite loop */
+	/* USER CODE BEGIN WHILE */
+	while (1) {
 
-	  if (!voltage_offset(pedal.first_v, pedal.second_v) || !voltage_check(pedal.user_v)) {
-	      	pedal.time_check += 1;
-	      }
-	      else {
-	      	if (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_7)) {
-	      		HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_7); //Turn off APPS if already active
-	      	}
-	      	pedal.time_check = 0;
-	      }
+		if (!voltage_offset(pedal.first_v, pedal.second_v)
+				|| !voltage_check(pedal.user_v)) {
+			pedal.time_check += 1;
+		} else {
+			if (HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_7)) {
+				HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_7); //Turn off APPS if already active
+			}
+			if (pedal.time_check > 0) {
+				pedal.time_check -= 1;
+			}
+			if (pedal.time_check == 0) {
+				pedal.time_check_true = 0;
+			}
+		}
 
-	      if (time_fault_check(pedal.time_check)) {
-	      	// convert_rpm(raw value goes here)
+		if (time_fault_check(pedal.time_check) && pedal.time_check_true) {
+			// convert_rpm(raw value goes here)
 
-	      	// throttle = lookup_table(convert_throttle_input(adc_throttle_buf), steering_wheel_angle_to_steering_angle(adc_steering_buf));
-	      	write_throttle_out(throttle, hdac);
-	          // Do torque vectoring
-	      }
-	      else {
-	      	throttle.left = 0;
-	      	throttle.right = 0;
-	      	write_throttle_out(throttle, hdac);
-	      	if (!HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_7)) {
-	      		HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_7);
-	      	}
-	      	pedal.time_check = 44444;
-	        // Output diagnostic light and output APPS SIGNAL.
-	      }
+			// throttle = lookup_table(convert_throttle_input(adc_throttle_buf), steering_wheel_angle_to_steering_angle(adc_steering_buf));
+			write_throttle_out(throttle, hdac);
+			// Do torque vectoring
+		} else {
+			throttle.left = 0;
+			throttle.right = 0;
+			write_throttle_out(throttle, hdac);
+			if (!HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_7)) {
+				HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_7);
+			}
+			if (time_fault_check(pedal.time_check)) {
+				pedal.time_check_true = 1;
+			}
+			// Output diagnostic light and output APPS SIGNAL.
+		}
 
-	      // Write out to SD card
+		// Write out to SD card
 
-    //SD Logging:
-    /*if(HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_6)){
-    	sd_unmount("/");
-    	file_res = sd_mount("/");
-    	if(file_res == FR_OK){
-    		detect = 1;
-    		if(detect_last == 0 && detect == 1 || !file_name){
-    			//Create a new file
-    			//With Headers:
-    			//sprintf(<header1>, "<type>", <header_value>)
-    			//file_length = strlen(header1) + ... + strlen(headerN);
-    			//file_name = (char *) malloc (file_length * sizeof(char))
-    			//snprintf(file_name, file_length, "<type1> - ... - <typeN>", <value1>, ... , <valueN>);
-    			//sd_format();
-    			//file_res = file_create(file_name);
-    			//sd_unmount("/");
-    			//csv_header(file_name, file_length);
-    			//detect_last = detect;
-    		}
-    		//Turn on LED
-    		//HAL_GPIO_WritePin(GPIO pin, function, 1)
-    		csv_update(file_name, file_length);
-    		file_index++;
-    	} else{
-    		if(file_name){
-    			free(file_name);
-    			file_name = NULL;
-    		}
-    		detect = 0;
-    		//Turn LED off when not detected
-    		//HAL_GPIO_WritePin(GPIO pin, function, 0)
-    		detect_last = detect;
-    	}
-    } else {
-    	if(file_name){
-    		free(file_name);
-    	    file_name = NULL;
-    	}
-    	detect = 0;
-    	//Turn LED off when not detected
-    	//HAL_GPIO_WritePin(GPIO pin, function, 0)
+		//SD Logging:
+		/*if(HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_6)){
+		 sd_unmount("/");
+		 file_res = sd_mount("/");
+		 if(file_res == FR_OK){
+		 detect = 1;
+		 if(detect_last == 0 && detect == 1 || !file_name){
+		 //Create a new file
+		 //With Headers:
+		 //sprintf(<header1>, "<type>", <header_value>)
+		 //file_length = strlen(header1) + ... + strlen(headerN);
+		 //file_name = (char *) malloc (file_length * sizeof(char))
+		 //snprintf(file_name, file_length, "<type1> - ... - <typeN>", <value1>, ... , <valueN>);
+		 //sd_format();
+		 //file_res = file_create(file_name);
+		 //sd_unmount("/");
+		 //csv_header(file_name, file_length);
+		 //detect_last = detect;
+		 }
+		 //Turn on LED
+		 //HAL_GPIO_WritePin(GPIO pin, function, 1)
+		 csv_update(file_name, file_length);
+		 file_index++;
+		 } else{
+		 if(file_name){
+		 free(file_name);
+		 file_name = NULL;
+		 }
+		 detect = 0;
+		 //Turn LED off when not detected
+		 //HAL_GPIO_WritePin(GPIO pin, function, 0)
+		 detect_last = detect;
+		 }
+		 } else {
+		 if(file_name){
+		 free(file_name);
+		 file_name = NULL;
+		 }
+		 detect = 0;
+		 //Turn LED off when not detected
+		 //HAL_GPIO_WritePin(GPIO pin, function, 0)
 
-    	detect_last = detect;
+		 detect_last = detect;
 
-    }*/
+		 }*/
 
-    /* USER CODE END WHILE */
+		/* USER CODE END WHILE */
 
-    /* USER CODE BEGIN 3 */
-  }
-  /* USER CODE END 3 */
+		/* USER CODE BEGIN 3 */
+	}
+	/* USER CODE END 3 */
 }
 
 /**
-  * @brief System Clock Configuration
-  * @retval None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+ * @brief System Clock Configuration
+ * @retval None
+ */
+void SystemClock_Config(void) {
+	RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
+	RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
 
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_RCC_PWR_CLK_ENABLE();
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE3);
+	/** Configure the main internal regulator output voltage
+	 */
+	__HAL_RCC_PWR_CLK_ENABLE();
+	__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE3);
 
-  /** Initializes the RCC Oscillators according to the specified parameters
-  * in the RCC_OscInitTypeDef structure.
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
+	/** Initializes the RCC Oscillators according to the specified parameters
+	 * in the RCC_OscInitTypeDef structure.
+	 */
+	RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+	RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+	RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+	RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+	if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+		Error_Handler();
+	}
 
-  /** Initializes the CPU, AHB and APB buses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+	/** Initializes the CPU, AHB and APB buses clocks
+	 */
+	RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+			| RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+	RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
+	RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+	RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+	RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0) != HAL_OK)
-  {
-    Error_Handler();
-  }
+	if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0) != HAL_OK) {
+		Error_Handler();
+	}
 }
 
 /**
-  * @brief ADC1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC1_Init(void)
-{
+ * @brief ADC1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC1_Init(void) {
 
-  /* USER CODE BEGIN ADC1_Init 0 */
+	/* USER CODE BEGIN ADC1_Init 0 */
 
-  /* USER CODE END ADC1_Init 0 */
+	/* USER CODE END ADC1_Init 0 */
 
-  ADC_ChannelConfTypeDef sConfig = {0};
+	ADC_ChannelConfTypeDef sConfig = { 0 };
 
-  /* USER CODE BEGIN ADC1_Init 1 */
+	/* USER CODE BEGIN ADC1_Init 1 */
 
-  /* USER CODE END ADC1_Init 1 */
+	/* USER CODE END ADC1_Init 1 */
 
-  /** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
-  */
-  hadc1.Instance = ADC1;
-  hadc1.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
-  hadc1.Init.Resolution = ADC_RESOLUTION_12B;
-  hadc1.Init.ScanConvMode = DISABLE;
-  hadc1.Init.ContinuousConvMode = DISABLE;
-  hadc1.Init.DiscontinuousConvMode = DISABLE;
-  hadc1.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-  hadc1.Init.ExternalTrigConv = ADC_SOFTWARE_START;
-  hadc1.Init.DataAlign = ADC_DATAALIGN_RIGHT;
-  hadc1.Init.NbrOfConversion = 1;
-  hadc1.Init.DMAContinuousRequests = DISABLE;
-  hadc1.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  if (HAL_ADC_Init(&hadc1) != HAL_OK)
-  {
-    Error_Handler();
-  }
+	/** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
+	 */
+	hadc1.Instance = ADC1;
+	hadc1.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
+	hadc1.Init.Resolution = ADC_RESOLUTION_12B;
+	hadc1.Init.ScanConvMode = DISABLE;
+	hadc1.Init.ContinuousConvMode = DISABLE;
+	hadc1.Init.DiscontinuousConvMode = DISABLE;
+	hadc1.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+	hadc1.Init.ExternalTrigConv = ADC_SOFTWARE_START;
+	hadc1.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+	hadc1.Init.NbrOfConversion = 1;
+	hadc1.Init.DMAContinuousRequests = DISABLE;
+	hadc1.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+	if (HAL_ADC_Init(&hadc1) != HAL_OK) {
+		Error_Handler();
+	}
 
-  /** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
-  */
-  sConfig.Channel = ADC_CHANNEL_10;
-  sConfig.Rank = 1;
-  sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
-  if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN ADC1_Init 2 */
+	/** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
+	 */
+	sConfig.Channel = ADC_CHANNEL_10;
+	sConfig.Rank = 1;
+	sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
+	if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN ADC1_Init 2 */
 
-  /* USER CODE END ADC1_Init 2 */
-
-}
-
-/**
-  * @brief ADC2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC2_Init(void)
-{
-
-  /* USER CODE BEGIN ADC2_Init 0 */
-
-  /* USER CODE END ADC2_Init 0 */
-
-  ADC_ChannelConfTypeDef sConfig = {0};
-
-  /* USER CODE BEGIN ADC2_Init 1 */
-
-  /* USER CODE END ADC2_Init 1 */
-
-  /** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
-  */
-  hadc2.Instance = ADC2;
-  hadc2.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
-  hadc2.Init.Resolution = ADC_RESOLUTION_12B;
-  hadc2.Init.ScanConvMode = DISABLE;
-  hadc2.Init.ContinuousConvMode = DISABLE;
-  hadc2.Init.DiscontinuousConvMode = DISABLE;
-  hadc2.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-  hadc2.Init.ExternalTrigConv = ADC_SOFTWARE_START;
-  hadc2.Init.DataAlign = ADC_DATAALIGN_RIGHT;
-  hadc2.Init.NbrOfConversion = 1;
-  hadc2.Init.DMAContinuousRequests = DISABLE;
-  hadc2.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  if (HAL_ADC_Init(&hadc2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-  /** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
-  */
-  sConfig.Channel = ADC_CHANNEL_11;
-  sConfig.Rank = 1;
-  sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
-  if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN ADC2_Init 2 */
-
-  /* USER CODE END ADC2_Init 2 */
+	/* USER CODE END ADC1_Init 2 */
 
 }
 
 /**
-  * @brief ADC3 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_ADC3_Init(void)
-{
+ * @brief ADC2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC2_Init(void) {
 
-  /* USER CODE BEGIN ADC3_Init 0 */
+	/* USER CODE BEGIN ADC2_Init 0 */
 
-  /* USER CODE END ADC3_Init 0 */
+	/* USER CODE END ADC2_Init 0 */
 
-  ADC_ChannelConfTypeDef sConfig = {0};
+	ADC_ChannelConfTypeDef sConfig = { 0 };
 
-  /* USER CODE BEGIN ADC3_Init 1 */
+	/* USER CODE BEGIN ADC2_Init 1 */
 
-  /* USER CODE END ADC3_Init 1 */
+	/* USER CODE END ADC2_Init 1 */
 
-  /** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
-  */
-  hadc3.Instance = ADC3;
-  hadc3.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
-  hadc3.Init.Resolution = ADC_RESOLUTION_12B;
-  hadc3.Init.ScanConvMode = DISABLE;
-  hadc3.Init.ContinuousConvMode = DISABLE;
-  hadc3.Init.DiscontinuousConvMode = DISABLE;
-  hadc3.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-  hadc3.Init.ExternalTrigConv = ADC_SOFTWARE_START;
-  hadc3.Init.DataAlign = ADC_DATAALIGN_RIGHT;
-  hadc3.Init.NbrOfConversion = 1;
-  hadc3.Init.DMAContinuousRequests = DISABLE;
-  hadc3.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-  if (HAL_ADC_Init(&hadc3) != HAL_OK)
-  {
-    Error_Handler();
-  }
+	/** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
+	 */
+	hadc2.Instance = ADC2;
+	hadc2.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
+	hadc2.Init.Resolution = ADC_RESOLUTION_12B;
+	hadc2.Init.ScanConvMode = DISABLE;
+	hadc2.Init.ContinuousConvMode = DISABLE;
+	hadc2.Init.DiscontinuousConvMode = DISABLE;
+	hadc2.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+	hadc2.Init.ExternalTrigConv = ADC_SOFTWARE_START;
+	hadc2.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+	hadc2.Init.NbrOfConversion = 1;
+	hadc2.Init.DMAContinuousRequests = DISABLE;
+	hadc2.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+	if (HAL_ADC_Init(&hadc2) != HAL_OK) {
+		Error_Handler();
+	}
 
-  /** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
-  */
-  sConfig.Channel = ADC_CHANNEL_12;
-  sConfig.Rank = 1;
-  sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
-  if (HAL_ADC_ConfigChannel(&hadc3, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN ADC3_Init 2 */
+	/** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
+	 */
+	sConfig.Channel = ADC_CHANNEL_11;
+	sConfig.Rank = 1;
+	sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
+	if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN ADC2_Init 2 */
 
-  /* USER CODE END ADC3_Init 2 */
+	/* USER CODE END ADC2_Init 2 */
 
 }
 
 /**
-  * @brief CAN1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_CAN1_Init(void)
-{
+ * @brief ADC3 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ADC3_Init(void) {
 
-  /* USER CODE BEGIN CAN1_Init 0 */
+	/* USER CODE BEGIN ADC3_Init 0 */
 
-  /* USER CODE END CAN1_Init 0 */
+	/* USER CODE END ADC3_Init 0 */
 
-  /* USER CODE BEGIN CAN1_Init 1 */
+	ADC_ChannelConfTypeDef sConfig = { 0 };
 
-  /* USER CODE END CAN1_Init 1 */
-  hcan1.Instance = CAN1;
-  hcan1.Init.Prescaler = 16;
-  hcan1.Init.Mode = CAN_MODE_NORMAL;
-  hcan1.Init.SyncJumpWidth = CAN_SJW_1TQ;
-  hcan1.Init.TimeSeg1 = CAN_BS1_1TQ;
-  hcan1.Init.TimeSeg2 = CAN_BS2_1TQ;
-  hcan1.Init.TimeTriggeredMode = DISABLE;
-  hcan1.Init.AutoBusOff = DISABLE;
-  hcan1.Init.AutoWakeUp = DISABLE;
-  hcan1.Init.AutoRetransmission = DISABLE;
-  hcan1.Init.ReceiveFifoLocked = DISABLE;
-  hcan1.Init.TransmitFifoPriority = DISABLE;
-  if (HAL_CAN_Init(&hcan1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN CAN1_Init 2 */
+	/* USER CODE BEGIN ADC3_Init 1 */
 
-  /* USER CODE END CAN1_Init 2 */
+	/* USER CODE END ADC3_Init 1 */
 
-}
+	/** Configure the global features of the ADC (Clock, Resolution, Data Alignment and number of conversion)
+	 */
+	hadc3.Instance = ADC3;
+	hadc3.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV2;
+	hadc3.Init.Resolution = ADC_RESOLUTION_12B;
+	hadc3.Init.ScanConvMode = DISABLE;
+	hadc3.Init.ContinuousConvMode = DISABLE;
+	hadc3.Init.DiscontinuousConvMode = DISABLE;
+	hadc3.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+	hadc3.Init.ExternalTrigConv = ADC_SOFTWARE_START;
+	hadc3.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+	hadc3.Init.NbrOfConversion = 1;
+	hadc3.Init.DMAContinuousRequests = DISABLE;
+	hadc3.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+	if (HAL_ADC_Init(&hadc3) != HAL_OK) {
+		Error_Handler();
+	}
 
-/**
-  * @brief DAC Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_DAC_Init(void)
-{
+	/** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
+	 */
+	sConfig.Channel = ADC_CHANNEL_12;
+	sConfig.Rank = 1;
+	sConfig.SamplingTime = ADC_SAMPLETIME_3CYCLES;
+	if (HAL_ADC_ConfigChannel(&hadc3, &sConfig) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN ADC3_Init 2 */
 
-  /* USER CODE BEGIN DAC_Init 0 */
-
-  /* USER CODE END DAC_Init 0 */
-
-  DAC_ChannelConfTypeDef sConfig = {0};
-
-  /* USER CODE BEGIN DAC_Init 1 */
-
-  /* USER CODE END DAC_Init 1 */
-
-  /** DAC Initialization
-  */
-  hdac.Instance = DAC;
-  if (HAL_DAC_Init(&hdac) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-  /** DAC channel OUT1 config
-  */
-  sConfig.DAC_Trigger = DAC_TRIGGER_NONE;
-  sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
-  if (HAL_DAC_ConfigChannel(&hdac, &sConfig, DAC_CHANNEL_1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-  /** DAC channel OUT2 config
-  */
-  if (HAL_DAC_ConfigChannel(&hdac, &sConfig, DAC_CHANNEL_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN DAC_Init 2 */
-
-  /* USER CODE END DAC_Init 2 */
+	/* USER CODE END ADC3_Init 2 */
 
 }
 
 /**
-  * @brief SPI1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_SPI1_Init(void)
-{
+ * @brief CAN1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_CAN1_Init(void) {
 
-  /* USER CODE BEGIN SPI1_Init 0 */
+	/* USER CODE BEGIN CAN1_Init 0 */
 
-  /* USER CODE END SPI1_Init 0 */
+	/* USER CODE END CAN1_Init 0 */
 
-  /* USER CODE BEGIN SPI1_Init 1 */
+	/* USER CODE BEGIN CAN1_Init 1 */
 
-  /* USER CODE END SPI1_Init 1 */
-  /* SPI1 parameter configuration*/
-  hspi1.Instance = SPI1;
-  hspi1.Init.Mode = SPI_MODE_MASTER;
-  hspi1.Init.Direction = SPI_DIRECTION_2LINES;
-  hspi1.Init.DataSize = SPI_DATASIZE_8BIT;
-  hspi1.Init.CLKPolarity = SPI_POLARITY_LOW;
-  hspi1.Init.CLKPhase = SPI_PHASE_1EDGE;
-  hspi1.Init.NSS = SPI_NSS_SOFT;
-  hspi1.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
-  hspi1.Init.FirstBit = SPI_FIRSTBIT_MSB;
-  hspi1.Init.TIMode = SPI_TIMODE_DISABLE;
-  hspi1.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
-  hspi1.Init.CRCPolynomial = 10;
-  if (HAL_SPI_Init(&hspi1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN SPI1_Init 2 */
+	/* USER CODE END CAN1_Init 1 */
+	hcan1.Instance = CAN1;
+	hcan1.Init.Prescaler = 16;
+	hcan1.Init.Mode = CAN_MODE_NORMAL;
+	hcan1.Init.SyncJumpWidth = CAN_SJW_1TQ;
+	hcan1.Init.TimeSeg1 = CAN_BS1_1TQ;
+	hcan1.Init.TimeSeg2 = CAN_BS2_1TQ;
+	hcan1.Init.TimeTriggeredMode = DISABLE;
+	hcan1.Init.AutoBusOff = DISABLE;
+	hcan1.Init.AutoWakeUp = DISABLE;
+	hcan1.Init.AutoRetransmission = DISABLE;
+	hcan1.Init.ReceiveFifoLocked = DISABLE;
+	hcan1.Init.TransmitFifoPriority = DISABLE;
+	if (HAL_CAN_Init(&hcan1) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN CAN1_Init 2 */
 
-  /* USER CODE END SPI1_Init 2 */
+	/* USER CODE END CAN1_Init 2 */
 
 }
 
 /**
-  * @brief TIM2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM2_Init(void)
-{
+ * @brief DAC Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_DAC_Init(void) {
 
-  /* USER CODE BEGIN TIM2_Init 0 */
+	/* USER CODE BEGIN DAC_Init 0 */
 
-  /* USER CODE END TIM2_Init 0 */
+	/* USER CODE END DAC_Init 0 */
 
-  TIM_MasterConfigTypeDef sMasterConfig = {0};
-  TIM_IC_InitTypeDef sConfigIC = {0};
+	DAC_ChannelConfTypeDef sConfig = { 0 };
 
-  /* USER CODE BEGIN TIM2_Init 1 */
+	/* USER CODE BEGIN DAC_Init 1 */
 
-  /* USER CODE END TIM2_Init 1 */
-  htim2.Instance = TIM2;
-  htim2.Init.Prescaler = 0;
-  htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim2.Init.Period = 4294967295;
-  htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-  htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_IC_Init(&htim2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
-  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
-  sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
-  sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
-  sConfigIC.ICFilter = 0;
-  if (HAL_TIM_IC_ConfigChannel(&htim2, &sConfigIC, TIM_CHANNEL_1) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN TIM2_Init 2 */
+	/* USER CODE END DAC_Init 1 */
 
-  /* USER CODE END TIM2_Init 2 */
+	/** DAC Initialization
+	 */
+	hdac.Instance = DAC;
+	if (HAL_DAC_Init(&hdac) != HAL_OK) {
+		Error_Handler();
+	}
+
+	/** DAC channel OUT1 config
+	 */
+	sConfig.DAC_Trigger = DAC_TRIGGER_NONE;
+	sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_ENABLE;
+	if (HAL_DAC_ConfigChannel(&hdac, &sConfig, DAC_CHANNEL_1) != HAL_OK) {
+		Error_Handler();
+	}
+
+	/** DAC channel OUT2 config
+	 */
+	if (HAL_DAC_ConfigChannel(&hdac, &sConfig, DAC_CHANNEL_2) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN DAC_Init 2 */
+
+	/* USER CODE END DAC_Init 2 */
 
 }
 
 /**
-  * @brief TIM5 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_TIM5_Init(void)
-{
+ * @brief SPI1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_SPI1_Init(void) {
 
-  /* USER CODE BEGIN TIM5_Init 0 */
+	/* USER CODE BEGIN SPI1_Init 0 */
 
-  /* USER CODE END TIM5_Init 0 */
+	/* USER CODE END SPI1_Init 0 */
 
-  TIM_MasterConfigTypeDef sMasterConfig = {0};
-  TIM_IC_InitTypeDef sConfigIC = {0};
+	/* USER CODE BEGIN SPI1_Init 1 */
 
-  /* USER CODE BEGIN TIM5_Init 1 */
+	/* USER CODE END SPI1_Init 1 */
+	/* SPI1 parameter configuration*/
+	hspi1.Instance = SPI1;
+	hspi1.Init.Mode = SPI_MODE_MASTER;
+	hspi1.Init.Direction = SPI_DIRECTION_2LINES;
+	hspi1.Init.DataSize = SPI_DATASIZE_8BIT;
+	hspi1.Init.CLKPolarity = SPI_POLARITY_LOW;
+	hspi1.Init.CLKPhase = SPI_PHASE_1EDGE;
+	hspi1.Init.NSS = SPI_NSS_SOFT;
+	hspi1.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
+	hspi1.Init.FirstBit = SPI_FIRSTBIT_MSB;
+	hspi1.Init.TIMode = SPI_TIMODE_DISABLE;
+	hspi1.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+	hspi1.Init.CRCPolynomial = 10;
+	if (HAL_SPI_Init(&hspi1) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN SPI1_Init 2 */
 
-  /* USER CODE END TIM5_Init 1 */
-  htim5.Instance = TIM5;
-  htim5.Init.Prescaler = 0;
-  htim5.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim5.Init.Period = 4294967295;
-  htim5.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-  htim5.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if (HAL_TIM_IC_Init(&htim5) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
-  sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-  if (HAL_TIMEx_MasterConfigSynchronization(&htim5, &sMasterConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
-  sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
-  sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
-  sConfigIC.ICFilter = 0;
-  if (HAL_TIM_IC_ConfigChannel(&htim5, &sConfigIC, TIM_CHANNEL_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN TIM5_Init 2 */
-
-  /* USER CODE END TIM5_Init 2 */
+	/* USER CODE END SPI1_Init 2 */
 
 }
 
 /**
-  * @brief USART2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_USART2_UART_Init(void)
-{
+ * @brief TIM2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM2_Init(void) {
 
-  /* USER CODE BEGIN USART2_Init 0 */
+	/* USER CODE BEGIN TIM2_Init 0 */
 
-  /* USER CODE END USART2_Init 0 */
+	/* USER CODE END TIM2_Init 0 */
 
-  /* USER CODE BEGIN USART2_Init 1 */
+	TIM_MasterConfigTypeDef sMasterConfig = { 0 };
+	TIM_IC_InitTypeDef sConfigIC = { 0 };
 
-  /* USER CODE END USART2_Init 1 */
-  huart2.Instance = USART2;
-  huart2.Init.BaudRate = 115200;
-  huart2.Init.WordLength = UART_WORDLENGTH_8B;
-  huart2.Init.StopBits = UART_STOPBITS_1;
-  huart2.Init.Parity = UART_PARITY_NONE;
-  huart2.Init.Mode = UART_MODE_TX_RX;
-  huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-  huart2.Init.OverSampling = UART_OVERSAMPLING_16;
-  if (HAL_UART_Init(&huart2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN USART2_Init 2 */
+	/* USER CODE BEGIN TIM2_Init 1 */
 
-  /* USER CODE END USART2_Init 2 */
+	/* USER CODE END TIM2_Init 1 */
+	htim2.Instance = TIM2;
+	htim2.Init.Prescaler = 0;
+	htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
+	htim2.Init.Period = 4294967295;
+	htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+	htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+	if (HAL_TIM_IC_Init(&htim2) != HAL_OK) {
+		Error_Handler();
+	}
+	sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+	sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+	if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig)
+			!= HAL_OK) {
+		Error_Handler();
+	}
+	sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+	sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
+	sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
+	sConfigIC.ICFilter = 0;
+	if (HAL_TIM_IC_ConfigChannel(&htim2, &sConfigIC, TIM_CHANNEL_1) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN TIM2_Init 2 */
+
+	/* USER CODE END TIM2_Init 2 */
 
 }
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_GPIO_Init(void)
-{
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-/* USER CODE BEGIN MX_GPIO_Init_1 */
-/* USER CODE END MX_GPIO_Init_1 */
+ * @brief TIM5 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_TIM5_Init(void) {
 
-  /* GPIO Ports Clock Enable */
-  __HAL_RCC_GPIOC_CLK_ENABLE();
-  __HAL_RCC_GPIOA_CLK_ENABLE();
-  __HAL_RCC_GPIOB_CLK_ENABLE();
+	/* USER CODE BEGIN TIM5_Init 0 */
 
-  /*Configure GPIO pin Output Level */
-  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_RESET);
+	/* USER CODE END TIM5_Init 0 */
 
-  /*Configure GPIO pin : PA6 */
-  GPIO_InitStruct.Pin = GPIO_PIN_6;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+	TIM_MasterConfigTypeDef sMasterConfig = { 0 };
+	TIM_IC_InitTypeDef sConfigIC = { 0 };
 
-  /*Configure GPIO pin : PC7 */
-  GPIO_InitStruct.Pin = GPIO_PIN_7;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+	/* USER CODE BEGIN TIM5_Init 1 */
 
-  /*Configure GPIO pin : PC8 */
-  GPIO_InitStruct.Pin = GPIO_PIN_8;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+	/* USER CODE END TIM5_Init 1 */
+	htim5.Instance = TIM5;
+	htim5.Init.Prescaler = 0;
+	htim5.Init.CounterMode = TIM_COUNTERMODE_UP;
+	htim5.Init.Period = 4294967295;
+	htim5.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+	htim5.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+	if (HAL_TIM_IC_Init(&htim5) != HAL_OK) {
+		Error_Handler();
+	}
+	sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+	sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+	if (HAL_TIMEx_MasterConfigSynchronization(&htim5, &sMasterConfig)
+			!= HAL_OK) {
+		Error_Handler();
+	}
+	sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+	sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
+	sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
+	sConfigIC.ICFilter = 0;
+	if (HAL_TIM_IC_ConfigChannel(&htim5, &sConfigIC, TIM_CHANNEL_2) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN TIM5_Init 2 */
 
-  /*Configure GPIO pin : PB6 */
-  GPIO_InitStruct.Pin = GPIO_PIN_6;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+	/* USER CODE END TIM5_Init 2 */
 
-/* USER CODE BEGIN MX_GPIO_Init_2 */
-/* USER CODE END MX_GPIO_Init_2 */
+}
+
+/**
+ * @brief USART2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_USART2_UART_Init(void) {
+
+	/* USER CODE BEGIN USART2_Init 0 */
+
+	/* USER CODE END USART2_Init 0 */
+
+	/* USER CODE BEGIN USART2_Init 1 */
+
+	/* USER CODE END USART2_Init 1 */
+	huart2.Instance = USART2;
+	huart2.Init.BaudRate = 115200;
+	huart2.Init.WordLength = UART_WORDLENGTH_8B;
+	huart2.Init.StopBits = UART_STOPBITS_1;
+	huart2.Init.Parity = UART_PARITY_NONE;
+	huart2.Init.Mode = UART_MODE_TX_RX;
+	huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+	huart2.Init.OverSampling = UART_OVERSAMPLING_16;
+	if (HAL_UART_Init(&huart2) != HAL_OK) {
+		Error_Handler();
+	}
+	/* USER CODE BEGIN USART2_Init 2 */
+
+	/* USER CODE END USART2_Init 2 */
+
+}
+
+/**
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_GPIO_Init(void) {
+	GPIO_InitTypeDef GPIO_InitStruct = { 0 };
+	/* USER CODE BEGIN MX_GPIO_Init_1 */
+	/* USER CODE END MX_GPIO_Init_1 */
+
+	/* GPIO Ports Clock Enable */
+	__HAL_RCC_GPIOC_CLK_ENABLE();
+	__HAL_RCC_GPIOA_CLK_ENABLE();
+	__HAL_RCC_GPIOB_CLK_ENABLE();
+
+	/*Configure GPIO pin Output Level */
+	HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_RESET);
+
+	/*Configure GPIO pin : PA6 */
+	GPIO_InitStruct.Pin = GPIO_PIN_6;
+	GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+	GPIO_InitStruct.Pull = GPIO_NOPULL;
+	HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+	/*Configure GPIO pin : PC7 */
+	GPIO_InitStruct.Pin = GPIO_PIN_7;
+	GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
+	GPIO_InitStruct.Pull = GPIO_PULLUP;
+	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+	HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+	/*Configure GPIO pin : PC8 */
+	GPIO_InitStruct.Pin = GPIO_PIN_8;
+	GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+	GPIO_InitStruct.Pull = GPIO_NOPULL;
+	HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+	/*Configure GPIO pin : PB6 */
+	GPIO_InitStruct.Pin = GPIO_PIN_6;
+	GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+	GPIO_InitStruct.Pull = GPIO_NOPULL;
+	HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+	/* USER CODE BEGIN MX_GPIO_Init_2 */
+	/* USER CODE END MX_GPIO_Init_2 */
 }
 
 /* USER CODE BEGIN 4 */
 //Only have access to GPIO pins in main
-void csv_header(char * file_name, int file_length) {
-	char name [file_length];
+void csv_header(char *file_name, int file_length) {
+	char name[file_length];
 	strcpy(name, file_name);
 	if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_6)) {
 		file_res = sd_mount("/");
@@ -763,9 +738,9 @@ void csv_header(char * file_name, int file_length) {
 	}
 }
 
-void csv_update(char * file_name, int file_length) {
+void csv_update(char *file_name, int file_length) {
 
-	char name [file_length];
+	char name[file_length];
 	strcpy(name, file_name);
 
 	if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_6)) {
@@ -774,8 +749,6 @@ void csv_update(char * file_name, int file_length) {
 		//sprintf(buffer, "<%unit>, measurement name"
 		//update_file(name, buffer);
 
-
-
 		sprintf(buffer, "\n\n");
 		file_res = file_update(name, buffer);
 		sd_unmount("/");
@@ -783,143 +756,121 @@ void csv_update(char * file_name, int file_length) {
 
 }
 
-void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
-{
-	if (htim->Channel == HAL_TIM_ACTIVE_CHANNEL_1)
-  {
-    if (tim2.Is_first_Captured == 0)
-    {
-      tim2.IC_Value1 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_1);
-      tim2.Is_first_Captured = 1;
-    }
-    else if (tim2.Is_first_Captured) {
-      tim2.IC_Value2 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_1);
-      if (tim2.IC_Value2 > tim2.IC_Value1)
-      {
-        tim2.Difference = tim2.IC_Value2 - tim2.IC_Value1;
-        tim2.Frequency = HAL_RCC_GetPCLK1Freq() / tim2.Difference;
-        tim2.CalculationOK = 1;
-        if (tim2.Current_Frequency == 0) {
-          tim2.Current_Frequency = tim2.Frequency;
-        }
-        else {
-          if(check_outliers(tim2.Current_Frequency, tim2.Frequency)) {
-            ++tim2.outlier_counter;
-            if (tim2.outlier_counter >= OUTLIER_COUNT) {
-              tim2.outlier_counter = 0;
-              HAL_Delay(1000);
-            }
-          }
-          else {
-            if(tim2.outlier_counter != 0)
-              tim2.outlier_counter = 0;
-            tim2.Current_Frequency = tim2.Frequency;
-          }
-        }
-      }
-      else
-        tim2.CalculationOK = 0;
-      tim2.Is_first_Captured = 0;
-    }
-  }
-  if (htim->Channel == HAL_TIM_ACTIVE_CHANNEL_3)
-  {
-    if (tim5.Is_first_Captured == 0)
-    {
-      tim5.IC_Value1 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_3);
-      tim5.Is_first_Captured = 1;
-    }
-    else if (tim5.Is_first_Captured) {
-      tim5.IC_Value2 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_3);
-      if (tim5.IC_Value2 > tim5.IC_Value1)
-      {
-        tim5.Difference = tim5.IC_Value2 - tim5.IC_Value1;
-        tim5.Frequency = HAL_RCC_GetPCLK1Freq() / tim5.Difference;
-        tim5.CalculationOK = 1;
-        if (tim5.Current_Frequency == 0) {
-          tim5.Current_Frequency = tim5.Frequency;
-        }
-        else {
-          if(check_outliers(tim5.Current_Frequency, tim5.Frequency)) {
-            ++tim5.outlier_counter;
-            if (tim5.outlier_counter >= OUTLIER_COUNT) {
-              tim5.outlier_counter = 0;
-              HAL_Delay(1000);
-            }
-          }
-          else {
-            if(tim5.outlier_counter != 0)
-              tim5.outlier_counter = 0;
-            tim5.Current_Frequency = tim5.Frequency;
-          }
-        }
-      }
-      else
-        tim5.CalculationOK = 0;
-      tim5.Is_first_Captured = 0;
-    }
-  }
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim) {
+	if (htim->Channel == HAL_TIM_ACTIVE_CHANNEL_1) {
+		if (tim2.Is_First_Captured == 0) {
+			tim2.IC_Value1 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_1);
+			tim2.Is_First_Captured = 1;
+		} else if (tim2.Is_First_Captured) {
+			tim2.IC_Value2 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_1);
+			if (tim2.IC_Value2 > tim2.IC_Value1) {
+				tim2.Current_Frequency = tim2.Frequency;
+				tim2.Difference = tim2.IC_Value2 - tim2.IC_Value1;
+				tim2.Frequency = HAL_RCC_GetPCLK1Freq() / tim2.Difference;
+				tim2.CalculationOK = 1;
+				if (check_outliers(tim2.Current_Frequency, tim2.Frequency)) {
+					if (tim2.outlier_counter >= 100000) {
+						tim2.outlier_counter = 0;
+						return;
+					}
+					if (tim2.outlier_counter == 0) {
+						tim2.Good_Frequency = tim2.Current_Frequency;
+					}
+					++tim2.outlier_counter;
+					if (tim2.outlier_counter >= OUTLIER_COUNT) {
+						tim2.outlier_counter = 0;
+						tim2.Frequency = tim2.Good_Frequency;
+					}
+				} else {
+					if (tim2.outlier_counter != 0)
+						tim2.outlier_counter = 0;
+				}
+			}
+		} else
+			tim2.CalculationOK = 0;
+		tim2.Is_First_Captured = 0;
+	}
+	if (htim->Channel == HAL_TIM_ACTIVE_CHANNEL_2) {
+		if (tim5.Is_First_Captured == 0) {
+			tim5.IC_Value1 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_2);
+			tim5.Is_First_Captured = 1;
+		} else if (tim5.Is_First_Captured) {
+			tim5.IC_Value2 = HAL_TIM_ReadCapturedValue(htim, TIM_CHANNEL_2);
+			if (tim5.IC_Value2 > tim5.IC_Value1) {
+				tim5.Current_Frequency = tim5.Frequency;
+				tim5.Difference = tim5.IC_Value2 - tim5.IC_Value1;
+				tim5.Frequency = HAL_RCC_GetPCLK1Freq() / tim5.Difference;
+				tim5.CalculationOK = 1;
+				if (check_outliers(tim5.Current_Frequency, tim5.Frequency)) {
+					if (tim5.outlier_counter >= 100000) {
+						tim5.outlier_counter = 0;
+						return;
+					}
+					if (tim5.outlier_counter == 0) {
+						tim5.Good_Frequency = tim5.Current_Frequency;
+					}
+					++tim5.outlier_counter;
+					if (tim5.outlier_counter >= OUTLIER_COUNT) {
+						tim5.outlier_counter = 0;
+						tim5.Frequency = tim5.Good_Frequency;
+					}
+				} else {
+					if (tim5.outlier_counter != 0)
+						tim5.outlier_counter = 0;
+				}
+			}
+		} else
+			tim5.CalculationOK = 0;
+		tim5.Is_First_Captured = 0;
+	}
 }
 
-void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
-{
-  float f;
-  uint16_t val;
+void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc) {
+	float f;
+	uint16_t val;
 
-  val = HAL_ADC_GetValue(hadc);
-  if (hadc == &hadc1)
-  { // Throttle Input
-    push_adc_buf(&adc_buf1, val);
-    f = convert_throttle_input(val);
-    push_throttle_in_buf(&throttle_buf, f);
-  }
-  else if (hadc == &hadc2)
-  { // Brake pedal sensor
-    push_adc_buf(&adc_buf2, val);
-  }
-  else if (hadc == &hadc3)
-  { // Steering angle sensor, extra analog input
-    push_adc_buf(&adc_buf3, val);
-    f = convert_steering_wheel_angle(val);
-    f = steering_wheel_angle_to_steering_angle(f);
-    push_steering_angle_buf(&steering_angle_buf, f);
-  }
+	val = HAL_ADC_GetValue(hadc);
+	if (hadc == &hadc1) { // Throttle Input
+		push_adc_buf(&adc_buf1, val);
+		f = convert_throttle_input(val);
+		push_throttle_in_buf(&throttle_buf, f);
+	} else if (hadc == &hadc2) { // Brake pedal sensor
+		push_adc_buf(&adc_buf2, val);
+	} else if (hadc == &hadc3) { // Steering angle sensor, extra analog input
+		push_adc_buf(&adc_buf3, val);
+		f = convert_steering_wheel_angle(val);
+		f = steering_wheel_angle_to_steering_angle(f);
+		push_steering_angle_buf(&steering_angle_buf, f);
+	}
 }
 
-
-int __io_putchar(int ch)
-{
+int __io_putchar(int ch) {
 	uint8_t c[1];
 	c[0] = ch & 0x00FF;
 	HAL_UART_Transmit_IT(&huart2, &*c, sizeof(c));
 	return ch;
-	}
+}
 
-	int _write(int file,char *ptr, int len)
-	{
+int _write(int file, char *ptr, int len) {
 	int DataIdx;
-	for(DataIdx= 0;
-	DataIdx< len; DataIdx++)
-	   {
-	   __io_putchar(*ptr++);
-	   }
+	for (DataIdx = 0; DataIdx < len; DataIdx++) {
+		__io_putchar(*ptr++);
+	}
 	return len;
 }
 /* USER CODE END 4 */
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @retval None
-  */
-void Error_Handler(void)
-{
-  /* USER CODE BEGIN Error_Handler_Debug */
-  /* User can add his own implementation to report the HAL error return state */
-  __disable_irq();
-  while (1)
-  {
-  }
-  /* USER CODE END Error_Handler_Debug */
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void) {
+	/* USER CODE BEGIN Error_Handler_Debug */
+	/* User can add his own implementation to report the HAL error return state */
+	__disable_irq();
+	while (1) {
+	}
+	/* USER CODE END Error_Handler_Debug */
 }
 
 #ifdef  USE_FULL_ASSERT

--- a/microcontroller/Core/Src/pedcon.c
+++ b/microcontroller/Core/Src/pedcon.c
@@ -66,7 +66,7 @@ Returns: If time_check surpasses a specified value representing time, then retur
 Else return 1.
 */
 int time_fault_check(uint32_t value) {
-    if (value > 44444)
+    if (value == 44444)
         return 0;
     return 1;
 }

--- a/simulation/graph.py
+++ b/simulation/graph.py
@@ -34,6 +34,7 @@ def display_graphs(time, ax, ay, wheel_velocity, total_slip, yaw_rate, des_rate)
 
     ax3.plot(time, yaw_rate, label='Yaw Rate')
     ax3.plot(time, des_rate, label='Desired Rate')
+    ax3.set_ylim(-5, 5)
     ax3.set_xlabel('Time (s)')
     ax3.set_ylabel('Yaw Rate (radians/s)')
     ax3.set_title('Yaw Rate and Desired Rate')

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -140,7 +140,7 @@ def calculate_desired_yaw_rate(v_cg, delta):
     # Return the calculated desired yaw rate
     return desired_yaw_rate
 
-def calculate_yaw_rate(t, Ku, Cy_f, Cy_r, Vx, St_a, Trr, Trl):
+def calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl):
     """
         Calculates the yaw rate of the vehicle given various parameters such as the
         cornering stiffness of the front and rear tires, current velocity, steering angle,
@@ -160,7 +160,7 @@ def calculate_yaw_rate(t, Ku, Cy_f, Cy_r, Vx, St_a, Trr, Trl):
             Ku (float): Yaw rate of the vehicle in radians per second
     """
     # Calculate the yaw rate using the given formula
-    Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * calculate_delta_torque(Trr, Trl)) / t
+    Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / (0.05 * Izz)) * calculate_delta_torque(Trr, Trl)) / t
     # Return the calculated yaw rate
     return Ku
 
@@ -221,7 +221,7 @@ def calculate_delta_torque(Trr, Trl):
             delt_T (float): Difference in torque between the rear left and rear right wheels in Nm.
     """
     # Calculate the delta torque using the given formula
-    delt_T = (Rw / ((2 * Tr) * Gr)) * calculate_yaw_moment(Trr, Trl)
+    delt_T = (Rw / (2 * Tr * Gr)) * calculate_yaw_moment(Trr, Trl)
 
     #return delt_T
     return delt_T
@@ -304,7 +304,7 @@ def simulate(v_cg, w_Velocity, rl_torqueWheel, rr_torqueWheel, steering_a):
         a_x.append(a_x[i] + LongAccel)
         wheel_velocity.append((rl_wheelAngularVelocity + rr_wheelAngularVelocity) / 2)
         a_y.append(calculate_lateral_velocity(v_cg, steering_a))
-        curr_yaw_rate.append(calculate_yaw_rate(i + 1, curr_yaw_rate[i], Cy_f, Cy_r, v_cg, steering_a, rr_torqueWheel, rl_torqueWheel))
+        curr_yaw_rate.append(calculate_yaw_rate(i + 1, curr_yaw_rate[i], v_cg, steering_a, rr_torqueWheel, rl_torqueWheel))
         des_yaw_rate.append(calculate_desired_yaw_rate(v_cg, steering_a))
 
     return a_x, a_y, wheel_velocity, curr_yaw_rate, des_yaw_rate
@@ -312,7 +312,7 @@ def simulate(v_cg, w_Velocity, rl_torqueWheel, rr_torqueWheel, steering_a):
 if __name__ == '__main__':
     
     # Simulate vehicle dynamics with given velocities, torque applied to each wheel, and steering wheel angle (in degrees)
-    ax, ay, wheel_velocity, yaw_rate, des_rate = simulate(1, 1, 10, 10, steering_wheel_angle_to_steering_angle(4))
+    ax, ay, wheel_velocity, yaw_rate, des_rate = simulate(1, 1, 40, 40, steering_wheel_angle_to_steering_angle(30))
 
     # desired_yaw_rate = calculate_desired_yaw_rate(random_velocity, random_steering_angle)
 

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -257,7 +257,10 @@ def steering_wheel_angle_to_steering_angle(steering_wheel_angle):
     """
     Converts steering wheel angle to actual steering angle
     """
-    x = (8.355 * pow(10, -5)) * steering_wheel_angle * steering_wheel_angle + 0.139 * steering_wheel_angle - 0.03133
+    if steering_wheel_angle >= 0:
+        x = (8.355 * (10**-5)) * (steering_wheel_angle ** 2) + (0.139 * steering_wheel_angle) - 0.03133
+    else:
+        x = (8.355 * (10**-5)) * (-steering_wheel_angle ** 2) + (0.139 * steering_wheel_angle) - 0.03133
     y = x * (math.pi/180)
     return y
 
@@ -289,7 +292,7 @@ def simulate(v_cg, w_Velocity, rl_torqueWheel, rr_torqueWheel, steering_a):
     curr_yaw_rate = arr.array('f', [0])
     des_yaw_rate = arr.array('f', [calculate_desired_yaw_rate(v_cg, steering_a)])
 
-    for i in range(100000):
+    for i in range(10000):
         rl_wheelAngularAccel = radians_to_ms((2*rl_torqueWheel) / (9 * wheelRadius))
         rr_wheelAngularAccel = radians_to_ms((2*rr_torqueWheel) / (9 * wheelRadius))
         rl_slippage = (v_cg + rl_wheelAngularAccel) / v_cg
@@ -297,7 +300,7 @@ def simulate(v_cg, w_Velocity, rl_torqueWheel, rr_torqueWheel, steering_a):
         rl_slippage = max(rl_slippage, 1.0)
         rr_slippage = max(rr_slippage, 1.0)
         F = magic_formula(weight / 2, (rl_slippage + rr_slippage) / 2)
-        LongAccel = (F / m) / 1000
+        LongAccel = (F / m) / 100
         v_cg = v_cg + LongAccel
         rl_wheelAngularVelocity = rl_slippage * v_cg
         rr_wheelAngularVelocity = rr_slippage * v_cg
@@ -312,7 +315,7 @@ def simulate(v_cg, w_Velocity, rl_torqueWheel, rr_torqueWheel, steering_a):
 if __name__ == '__main__':
     
     # Simulate vehicle dynamics with given velocities, torque applied to each wheel, and steering wheel angle (in degrees)
-    ax, ay, wheel_velocity, yaw_rate, des_rate = simulate(1, 1, 40, 40, steering_wheel_angle_to_steering_angle(30))
+    ax, ay, wheel_velocity, yaw_rate, des_rate = simulate(1, 1, 1, 1, steering_wheel_angle_to_steering_angle(-20))
 
     # desired_yaw_rate = calculate_desired_yaw_rate(random_velocity, random_steering_angle)
 
@@ -321,7 +324,7 @@ if __name__ == '__main__':
     time = arr.array('f', [0])
     total_slip = arr.array('f', [((wheel_velocity[i] / ax[i]) - 1) * 100])
     while i < len(ax):
-        time.append(i / 1000)
+        time.append(i / 100)
         total_slip.append(((wheel_velocity[i] / ax[i]) - 1) * 100)
         i += 1
     

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -146,11 +146,13 @@ def calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl):
         cornering stiffness of the front and rear tires, current velocity, steering angle,
         and torque applied to the rear wheels. The yaw rate is a measure of the vehicle's
         angular velocity around its vertical axis, and it is an important factor in
-        understanding the vehicle's handling and stability during turns.
+        understanding the vehicle's handling and stability during turns. Uses a jerk
+        calculation that is being divided by time to get acceleration of yaw rate, then
+        adding that to yaw rate velocity (Ku).
 
         Args:
-            Cy_f (float): Cornering stiffness of the front tires in N/rad
-            Cy_r (float): Cornering stiffness of the rear tires in N/rad
+            t, (int): Time in seconds
+            Ku, (float): Yaw rate velocity in radians/s
             Vx, (float): Current velocity of car in m/s
             St_a, (float): Current steering angle in radians
             Trr, (float): Current power from rear right wheel in Nm
@@ -255,7 +257,14 @@ def magic_formula(w, p, b=10, c=1.9, d=1, e=.97):
 
 def steering_wheel_angle_to_steering_angle(steering_wheel_angle):
     """
-    Converts steering wheel angle to actual steering angle
+    Converts steering wheel angle to actual steering angle. It uses if statements
+    to determine if input is negative, else it will result in the wrong calculation.
+    
+    Args:
+        steering_wheel_angle (float): Steering *wheel* angle in degrees.
+        
+    Returns:
+        Steering angle in radians.
     """
     if steering_wheel_angle >= 0:
         x = (8.355 * (10**-5)) * (steering_wheel_angle ** 2) + (0.139 * steering_wheel_angle) - 0.03133

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -23,15 +23,13 @@ def test_calculate_steer_gradient():
 
 def test_calculate_desired_yaw_rate():
     delta = random.uniform(-230, 230)
-    desired_yaw_rate = (v_cg / ((lf + lr) + (0.0012965 * math.pow(v_cg, 2)))) * delta
+    desired_yaw_rate = (v_cg / (lf + lr) - 0.00168 * math.pow(v_cg, 2)) * delta
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
-    Ku = 0
-    for t in range(1, 100000):
-        delta_torque = calculate_delta_torque(Trr, Trl)
-        Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
-        assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku
+    delta_torque = calculate_delta_torque(Trr, Trl)
+    Ku = ((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx)) + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque
+    assert calculate_yaw_rate(Cy_f, Cy_r, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -27,9 +27,10 @@ def test_calculate_desired_yaw_rate():
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
-    delta_torque = calculate_delta_torque(Trr, Trl)
-    Ku = Ku + ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
-    assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku
+    for t in range(100000):
+        delta_torque = calculate_delta_torque(Trr, Trl)
+        Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
+        assert calculate_yaw_rate(Ku, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -27,6 +27,7 @@ def test_calculate_desired_yaw_rate():
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
+    Ku = 0
     for t in range(100000):
         delta_torque = calculate_delta_torque(Trr, Trl)
         Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -28,7 +28,7 @@ def test_calculate_desired_yaw_rate():
 
 def test_calculate_yaw_rate():
     delta_torque = calculate_delta_torque(Trr, Trl)
-    Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
+    Ku = Ku + ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
     assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -27,10 +27,10 @@ def test_calculate_desired_yaw_rate():
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
-    for t in range(100000):
-        delta_torque = calculate_delta_torque(Trr, Trl)
-        Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
-        assert calculate_yaw_rate(Ku, Vx, St_a, Trr, Trl) == Ku
+    delta_torque = calculate_delta_torque(Trr, Trl)
+    Ku = 0
+    Ku += + ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
+    assert calculate_yaw_rate(Ku, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -23,13 +23,13 @@ def test_calculate_steer_gradient():
 
 def test_calculate_desired_yaw_rate():
     delta = random.uniform(-230, 230)
-    desired_yaw_rate = (v_cg / (lf + lr) - 0.00168 * math.pow(v_cg, 2)) * delta
+    desired_yaw_rate = (v_cg / ((lf + lr) + (0.0012965 * math.pow(v_cg, 2)))) * delta
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
     delta_torque = calculate_delta_torque(Trr, Trl)
-    Ku = ((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx)) + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque
-    assert calculate_yaw_rate(Cy_f, Cy_r, Vx, St_a, Trr, Trl) == Ku
+    Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
+    assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -23,13 +23,14 @@ def test_calculate_steer_gradient():
 
 def test_calculate_desired_yaw_rate():
     delta = random.uniform(-230, 230)
-    desired_yaw_rate = (v_cg / (lf + lr) - 0.00168 * math.pow(v_cg, 2)) * delta
+    desired_yaw_rate = (v_cg / ((lf + lr) + (0.0012965 * math.pow(v_cg, 2)))) * delta
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
     delta_torque = calculate_delta_torque(Trr, Trl)
-    Ku = ((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx)) + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque
-    assert calculate_yaw_rate(Cy_f, Cy_r, Vx, St_a, Trr, Trl) == Ku
+    Ku = t = random.uniform(0, 1000)
+    Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / (0.05 * Izz)) * delta_torque) / t
+    assert calculate_yaw_rate(t, t, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -28,7 +28,7 @@ def test_calculate_desired_yaw_rate():
 
 def test_calculate_yaw_rate():
     Ku = 0
-    for t in range(100000):
+    for t in range(1, 100000):
         delta_torque = calculate_delta_torque(Trr, Trl)
         Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
         assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku

--- a/simulation/test_simulation.py
+++ b/simulation/test_simulation.py
@@ -27,10 +27,10 @@ def test_calculate_desired_yaw_rate():
     assert calculate_desired_yaw_rate(v_cg, delta) == desired_yaw_rate
 
 def test_calculate_yaw_rate():
-    delta_torque = calculate_delta_torque(Trr, Trl)
-    Ku = 0
-    Ku += + ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
-    assert calculate_yaw_rate(Ku, Vx, St_a, Trr, Trl) == Ku
+    for t in range(100000):
+        delta_torque = calculate_delta_torque(Trr, Trl)
+        Ku += ((((-lf * Cy_f + lr * Cy_r) / (Izz * Vx)) - ((lf**2 * Cy_f + lr**2 * Cy_r) / (Izz * Vx))) * Ku + ((lf * Cy_f) / Izz) * St_a + (1 / 0.05 * Izz) * delta_torque) / t
+        assert calculate_yaw_rate(t, Ku, Vx, St_a, Trr, Trl) == Ku
 
 def test_calculate_yaw_moment():
     M_V = (Trr - Trl) * Tr


### PR DESCRIPTION
-Fixed yaw rate calculation. It was not dividng by time since it was a jerk calculation. Needed to divide by time to get yaw rate acceleration and added it to yaw rate velocity. It also was not using the previous yaw rate velocity in the calculation.
-Fixed desired yaw rate calculation. Constant Ku was incorrect in the calculation, it needed to be positive.
-Added much more resolution to the simulation. Mostly to reduce the yaw rate calculation outliers at the start of the simulation.
-Added a y limit for yaw rate graphing. Change it if you need to see data better.